### PR TITLE
private指定できるところの検討

### DIFF
--- a/GithubAPIPractice/Models/GithubApiModel.swift
+++ b/GithubAPIPractice/Models/GithubApiModel.swift
@@ -54,8 +54,7 @@ extension Reactive where Base: GithubApiModel {
                 }
             }
             return Disposables.create()
-            //この下のshared以下は不要
-        }.share(replay: 1, scope: .whileConnected)
+        }
         
     }
 }

--- a/GithubAPIPractice/ViewModels/DetailViewModel.swift
+++ b/GithubAPIPractice/ViewModels/DetailViewModel.swift
@@ -26,7 +26,7 @@ protocol DetailViewModelOutput {
 
 final class DetailViewModel: DetailViewModelOutput {
     
-    var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     /*Inputに関する記述*/
 //    let urlButtonSelect: Observable<Void>
     

--- a/GithubAPIPractice/ViewModels/IssueListViewModel.swift
+++ b/GithubAPIPractice/ViewModels/IssueListViewModel.swift
@@ -17,8 +17,8 @@ protocol IssueListViewModelOutput {
     //privateで流したい
     //このままだと、ViewControllerからshowLoadingを流すことができてしまう
     var dataRelay: BehaviorRelay<[SectionModel]> { get }
-    // 検索中か
-//    var isLoading: Observable<Bool> { get }
+
+    //各種View用の出力情報をDriverとして出力することができると尚良い
 }
 
 final class IssueListViewModel: IssueListViewModelOutput {
@@ -29,13 +29,20 @@ final class IssueListViewModel: IssueListViewModelOutput {
     //(refs: "https://stackoverflow.com/questions/54213183/display-activity-indicator-with-rxswift-and-mvvm")
     
 //    privateをつけないと、ViewController側からViewModel内のshowLoadingに対して直接acceptしてデータを流すことが出来てしまいます。
-    
+    private let showLoadingRelay = BehaviorRelay<Bool>(value: true)
+    var showLoading: Driver<Bool> {
+        showLoadingRelay.asDriver()
+    }
 
-
-    let showLoading = BehaviorRelay<Bool>(value: true)
     
     /*Outputに関する記述*/
+    //ここもDriverに変換できる？
     lazy var dataRelay = BehaviorRelay<[SectionModel]>(value: [])
+    //↓だとうまくいかなかった
+//    private var dataRelay = BehaviorRelay<[SectionModel]>(value: [])
+//    var dataDriver: Driver<[SectionModel]> {
+//        dataRelay.asDriver()
+//    }
     
     init() {
         sectionModel = [SectionModel(items: [])]
@@ -52,7 +59,7 @@ final class IssueListViewModel: IssueListViewModelOutput {
     //errorを書くとしたらここ？
     //ViewModelからエラーを受け取って、Viewでアラートやボタンの表示を行いたい
     func requestGithubIssue() {
-        showLoading.accept(true)
+        showLoadingRelay.accept(true)
         
         GithubApiModel.shared.rx.request()
             .map { repositories -> [SectionModel] in
@@ -62,7 +69,7 @@ final class IssueListViewModel: IssueListViewModelOutput {
     .bind(to: dataRelay)
     .disposed(by: disposeBag)
     
-        showLoading.accept(false)
+        showLoadingRelay.accept(false)
     }
 
 }

--- a/GithubAPIPractice/ViewModels/IssueListViewModel.swift
+++ b/GithubAPIPractice/ViewModels/IssueListViewModel.swift
@@ -15,9 +15,7 @@ protocol IssueListViewModelOutput {
     //RxDataSources
     //画面遷移する際に値を渡す
     //privateで流したい
-    //このままだと、ViewControllerからshowLoadingを流すことができてしまう
-    var dataRelay: BehaviorRelay<[SectionModel]> { get }
-
+    var issueListStream: Observable<[SectionModel]> { get }
     //各種View用の出力情報をDriverとして出力することができると尚良い
 }
 
@@ -36,13 +34,10 @@ final class IssueListViewModel: IssueListViewModelOutput {
 
     
     /*Outputに関する記述*/
-    //ここもDriverに変換できる？
-    lazy var dataRelay = BehaviorRelay<[SectionModel]>(value: [])
+//    lazy var dataRelay = BehaviorRelay<[SectionModel]>(value: [])
     //↓だとうまくいかなかった
-//    private var dataRelay = BehaviorRelay<[SectionModel]>(value: [])
-//    var dataDriver: Driver<[SectionModel]> {
-//        dataRelay.asDriver()
-//    }
+    private let issueListRelay = BehaviorRelay<[SectionModel]>(value: [])
+    var issueListStream: Observable<[SectionModel]> { issueListRelay.asObservable() }
     
     init() {
         sectionModel = [SectionModel(items: [])]
@@ -50,7 +45,7 @@ final class IssueListViewModel: IssueListViewModelOutput {
         //dataRelayに初期設定のsectionModelを流す
         Observable.deferred { () -> Observable<[SectionModel]> in
             return Observable.just(self.sectionModel)
-        }.bind(to: dataRelay)
+        }.bind(to: issueListRelay)
         .disposed(by: disposeBag)
         
     }
@@ -66,7 +61,7 @@ final class IssueListViewModel: IssueListViewModelOutput {
                 [SectionModel(items: repositories)]
             }
     //dateRelayに新しいSectionModelを流すと勝手にreloadしてくれる
-    .bind(to: dataRelay)
+    .bind(to: issueListRelay)
     .disposed(by: disposeBag)
     
         showLoadingRelay.accept(false)

--- a/GithubAPIPractice/Views/DetailViewController.swift
+++ b/GithubAPIPractice/Views/DetailViewController.swift
@@ -14,7 +14,7 @@ final class DetailViewController: UIViewController {
     
     //modelのインスタンス
     private var viewModel: DetailViewModel!
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
 
     private lazy var output: DetailViewModelOutput = viewModel
     
@@ -35,7 +35,8 @@ final class DetailViewController: UIViewController {
     }
 
     //labelにIssueListViewControllerから受け取ったIssueを元に、表示を行う
-    func bind() {
+    // TODO: rename
+    private func bind() {
         self.viewModel.title
             .bind(to: self.titleLabel.rx.text)
             .disposed(by: disposeBag)

--- a/GithubAPIPractice/Views/IssueListViewController.swift
+++ b/GithubAPIPractice/Views/IssueListViewController.swift
@@ -57,7 +57,7 @@ final class IssueListViewController: UIViewController {
         })
         
         //dateRelayの変更を感知してdataSourceにデータを流す
-        output.dataRelay.asObservable()
+        output.issueListStream
             .bind(to: tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         

--- a/GithubAPIPractice/Views/IssueListViewController.swift
+++ b/GithubAPIPractice/Views/IssueListViewController.swift
@@ -25,18 +25,18 @@ final class IssueListViewController: UIViewController {
     
     //modelのインスタンス
     private var viewModel = IssueListViewModel()
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     private lazy var output: IssueListViewModelOutput = viewModel
     
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet weak var indicatorView: UIActivityIndicatorView!
+    @IBOutlet private weak var indicatorView: UIActivityIndicatorView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         tableView.registerCustomCell(IssueListTableViewCell.self)
         setUpTableView()
-        animate()
+        showIndicator()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -46,7 +46,7 @@ final class IssueListViewController: UIViewController {
         viewModel.requestGithubIssue()
     }
     
-    func setUpTableView() {
+    private func setUpTableView() {
         
         //RxDataSources
         let dataSource = RxTableViewSectionedReloadDataSource<SectionModel>(configureCell: { _, tableView, indexPath, item in
@@ -78,7 +78,7 @@ final class IssueListViewController: UIViewController {
     //request -> 表示の間だけくるくる回るようにしたいが、実装できなかったです
     //出てきたけどよくわからなかったもの "https://github.com/ReactiveX/RxSwift/blob/main/RxExample/RxExample/Services/ActivityIndicator.swift"
     
-    func animate() {
+    private func showIndicator() {
         // isAnimatingのフラグをIndicatorのisAnimatingに連携させる
       viewModel.showLoading.asDriver()
           .drive(indicatorView.rx.isAnimating)


### PR DESCRIPTION
# やったこと
privateをつけられそうな部分に付けました。
チケット
https://app.asana.com/0/1202068927070771/1202090985460776

# 疑問点1
コメントしたんですが、
IssueListViewModel のdataRelay についてもprivateにできるかもしれないと思ったのですが、うまく実装できなかったです
Driverに変換したからだと思うんですが、何か他にいい方法があったらご教授いただきたいです。

# 疑問点2
他にprivateにできそうな部分と、その理由がお聞きしたいです。