### PR TITLE
 RxDataSourcesを使わないようにする, 脱シングルトン

### DIFF
--- a/GithubAPIPractice.xcodeproj/project.pbxproj
+++ b/GithubAPIPractice.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		A406065827C9E21400440A49 /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A406065727C9E21400440A49 /* DetailViewModel.swift */; };
 		A406065A27C9E22200440A49 /* IssueListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A406065927C9E22200440A49 /* IssueListViewModel.swift */; };
-		A406065E27CCD30700440A49 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = A406065D27CCD30700440A49 /* User.swift */; };
 		A409090427B78213000C0D16 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409090327B78213000C0D16 /* AppDelegate.swift */; };
 		A409090627B78213000C0D16 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409090527B78213000C0D16 /* SceneDelegate.swift */; };
 		A409090827B78213000C0D16 /* IssueListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409090727B78213000C0D16 /* IssueListViewController.swift */; };
@@ -25,7 +24,6 @@
 		A409094227BE30A9000C0D16 /* TableView +.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409094127BE30A9000C0D16 /* TableView +.swift */; };
 		A409094427BE30EF000C0D16 /* TableViewCell +.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409094327BE30EF000C0D16 /* TableViewCell +.swift */; };
 		A409094627BF87E6000C0D16 /* GithubIssuesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A409094527BF87E6000C0D16 /* GithubIssuesRepository.swift */; };
-		A42DB38628068CF000CBB9A4 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42DB38528068CF000CBB9A4 /* Issue.swift */; };
 		A42DB38A28069CA900CBB9A4 /* IssueListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42DB38928069CA900CBB9A4 /* IssueListUseCase.swift */; };
 		A478249527CD1B300038D923 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = A478249427CD1B300038D923 /* RxDataSources */; };
 		A478249A27CDD1070038D923 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = A478249927CDD1070038D923 /* Kingfisher */; };
@@ -36,6 +34,8 @@
 		A4EC76DA27D0C81F00ECE310 /* RxOptional in Frameworks */ = {isa = PBXBuildFile; productRef = A4EC76D927D0C81F00ECE310 /* RxOptional */; };
 		A4EC76E727D1F58700ECE310 /* MBProgressHUD in Frameworks */ = {isa = PBXBuildFile; productRef = A4EC76E627D1F58700ECE310 /* MBProgressHUD */; };
 		CD720C89280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */; };
+		CD720C8C280D608F0088E2FF /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD720C8B280D608F0088E2FF /* User.swift */; };
+		CD720C8E280D609C0088E2FF /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD720C8D280D609C0088E2FF /* Issue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,7 +58,6 @@
 /* Begin PBXFileReference section */
 		A406065727C9E21400440A49 /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		A406065927C9E22200440A49 /* IssueListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListViewModel.swift; sourceTree = "<group>"; };
-		A406065D27CCD30700440A49 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		A409090027B78213000C0D16 /* GithubAPIPractice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GithubAPIPractice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A409090327B78213000C0D16 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A409090527B78213000C0D16 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -78,13 +77,14 @@
 		A409094127BE30A9000C0D16 /* TableView +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableView +.swift"; sourceTree = "<group>"; };
 		A409094327BE30EF000C0D16 /* TableViewCell +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableViewCell +.swift"; sourceTree = "<group>"; };
 		A409094527BF87E6000C0D16 /* GithubIssuesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubIssuesRepository.swift; sourceTree = "<group>"; };
-		A42DB38528068CF000CBB9A4 /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		A42DB38928069CA900CBB9A4 /* IssueListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListUseCase.swift; sourceTree = "<group>"; };
 		A478249B27CDD7A50038D923 /* Detail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Detail.storyboard; sourceTree = "<group>"; };
 		A478249D27CDE9A60038D923 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		A478249F27CDEF860038D923 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		A4EC76D427D0B04500ECE310 /* UIButton +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton +.swift"; sourceTree = "<group>"; };
 		CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubIssuesRepositoryProtocol.swift; sourceTree = "<group>"; };
+		CD720C8B280D608F0088E2FF /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		CD720C8D280D609C0088E2FF /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,15 +211,6 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		A42DB3882806902600CBB9A4 /* DomainObject */ = {
-			isa = PBXGroup;
-			children = (
-				A406065D27CCD30700440A49 /* User.swift */,
-				A42DB38528068CF000CBB9A4 /* Issue.swift */,
-			);
-			path = DomainObject;
-			sourceTree = "<group>";
-		};
 		A478249327CD1B300038D923 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -266,9 +257,18 @@
 			children = (
 				A42DB38928069CA900CBB9A4 /* IssueListUseCase.swift */,
 				CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */,
-				A42DB3882806902600CBB9A4 /* DomainObject */,
+				CD720C8A280D607C0088E2FF /* DomainObject */,
 			);
 			path = Domain;
+			sourceTree = "<group>";
+		};
+		CD720C8A280D607C0088E2FF /* DomainObject */ = {
+			isa = PBXGroup;
+			children = (
+				CD720C8B280D608F0088E2FF /* User.swift */,
+				CD720C8D280D609C0088E2FF /* Issue.swift */,
+			);
+			path = DomainObject;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -417,12 +417,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A406065E27CCD30700440A49 /* User.swift in Sources */,
 				A409090827B78213000C0D16 /* IssueListViewController.swift in Sources */,
 				CD720C89280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift in Sources */,
-				A42DB38628068CF000CBB9A4 /* Issue.swift in Sources */,
+				CD720C8E280D609C0088E2FF /* Issue.swift in Sources */,
 				A409090427B78213000C0D16 /* AppDelegate.swift in Sources */,
 				A42DB38A28069CA900CBB9A4 /* IssueListUseCase.swift in Sources */,
+				CD720C8C280D608F0088E2FF /* User.swift in Sources */,
 				A4EC76D527D0B04500ECE310 /* UIButton +.swift in Sources */,
 				A409090627B78213000C0D16 /* SceneDelegate.swift in Sources */,
 				A409094027BE3094000C0D16 /* NSObject +.swift in Sources */,

--- a/GithubAPIPractice.xcodeproj/project.pbxproj
+++ b/GithubAPIPractice.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A4EC76D527D0B04500ECE310 /* UIButton +.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EC76D427D0B04500ECE310 /* UIButton +.swift */; };
 		A4EC76DA27D0C81F00ECE310 /* RxOptional in Frameworks */ = {isa = PBXBuildFile; productRef = A4EC76D927D0C81F00ECE310 /* RxOptional */; };
 		A4EC76E727D1F58700ECE310 /* MBProgressHUD in Frameworks */ = {isa = PBXBuildFile; productRef = A4EC76E627D1F58700ECE310 /* MBProgressHUD */; };
+		CD720C89280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +84,7 @@
 		A478249D27CDE9A60038D923 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		A478249F27CDEF860038D923 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		A4EC76D427D0B04500ECE310 /* UIButton +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton +.swift"; sourceTree = "<group>"; };
+		CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubIssuesRepositoryProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,9 +194,8 @@
 		A409093D27BE22F1000C0D16 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				A42DB38928069CA900CBB9A4 /* IssueListUseCase.swift */,
-				A409094527BF87E6000C0D16 /* GithubIssuesRepository.swift */,
-				A42DB3882806902600CBB9A4 /* DomainObject */,
+				CD720C86280D393A0088E2FF /* Infra */,
+				CD720C87280D39550088E2FF /* Domain */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -250,6 +251,24 @@
 				A478249D27CDE9A60038D923 /* Router.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		CD720C86280D393A0088E2FF /* Infra */ = {
+			isa = PBXGroup;
+			children = (
+				A409094527BF87E6000C0D16 /* GithubIssuesRepository.swift */,
+			);
+			path = Infra;
+			sourceTree = "<group>";
+		};
+		CD720C87280D39550088E2FF /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				A42DB38928069CA900CBB9A4 /* IssueListUseCase.swift */,
+				CD720C88280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift */,
+				A42DB3882806902600CBB9A4 /* DomainObject */,
+			);
+			path = Domain;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -400,6 +419,7 @@
 			files = (
 				A406065E27CCD30700440A49 /* User.swift in Sources */,
 				A409090827B78213000C0D16 /* IssueListViewController.swift in Sources */,
+				CD720C89280D39920088E2FF /* GithubIssuesRepositoryProtocol.swift in Sources */,
 				A42DB38628068CF000CBB9A4 /* Issue.swift in Sources */,
 				A409090427B78213000C0D16 /* AppDelegate.swift in Sources */,
 				A42DB38A28069CA900CBB9A4 /* IssueListUseCase.swift in Sources */,

--- a/GithubAPIPractice/Models/Domain/DomainObject/Issue.swift
+++ b/GithubAPIPractice/Models/Domain/DomainObject/Issue.swift
@@ -1,0 +1,20 @@
+//
+//  Issue.swift
+//  GithubAPIPractice
+//
+//  Created by Kazuma Miura on 2022/04/18.
+//
+
+import Foundation
+
+/// GitHubのissueの情報
+struct Issue {
+    let number: Int
+    let title: String // 一覧画面・詳細画面に表示
+    let body: String // 詳細画面に表示
+    let url: URL // 詳細画面に表示し、それをタップしたらSafariViewControllerで開く
+    let user: User // 一覧画面にアバター画像と名前を表示
+    let updatedAt: String // 一覧画面・詳細画面に表示
+    //Date型のまま流すと、Viewで加工する必要がある
+    
+}

--- a/GithubAPIPractice/Models/Domain/DomainObject/User.swift
+++ b/GithubAPIPractice/Models/Domain/DomainObject/User.swift
@@ -1,0 +1,15 @@
+//
+//  User.swift
+//  GithubAPIPractice
+//
+//  Created by Kazuma Miura on 2022/04/18.
+//
+
+import Foundation
+
+///// Githubのuser情報
+struct User {
+    let login: String
+    let avatarURL: URL
+
+}

--- a/GithubAPIPractice/Models/Domain/GithubIssuesRepositoryProtocol.swift
+++ b/GithubAPIPractice/Models/Domain/GithubIssuesRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  GithubIssuesRepositoryProtocol.swift
+//  GithubAPIPractice
+//
+//  Created by Kazuma Miura on 2022/04/18.
+//
+
+import Foundation
+import RxSwift
+
+protocol GithubIssuesRepositoryProtocol {
+    func fetch() -> Single<[Issue]>
+}

--- a/GithubAPIPractice/Models/Domain/IssueListUseCase.swift
+++ b/GithubAPIPractice/Models/Domain/IssueListUseCase.swift
@@ -11,10 +11,10 @@ import RxRelay
 //publicで書く理由: VMから参照したいから(repositoryからは参照しない)
 
 public class IssueListUseCase {
-    private let repository = GithubIssuesRepository()
+
     private let disposeBag = DisposeBag()
-
-
+    //repositoryをGithubIssuesRepositoryProtocolに適合させる(testableにするため)
+    private let repository: GithubIssuesRepositoryProtocol
     private let issuesRelay = BehaviorRelay<[Issue]?>(value: nil)
     //publicつかなかった
     var issues: Observable<[Issue]> {
@@ -23,7 +23,8 @@ public class IssueListUseCase {
             .asObservable()    //Observableに変換する
     }
 
-    public init() {
+    init(repository: GithubIssuesRepositoryProtocol) {
+        self.repository = repository
     }
 
     func fetch() {

--- a/GithubAPIPractice/Models/Infra/GithubIssuesRepository.swift
+++ b/GithubAPIPractice/Models/Infra/GithubIssuesRepository.swift
@@ -8,11 +8,11 @@
 import Foundation
 import RxSwift
 
-final class GithubIssuesRepository {
+final class GithubIssuesRepository: GithubIssuesRepositoryProtocol {
     
     //シングルトンにする
     //テスタブルじゃなくなってしまうから、避けた方がいい
-    static let shared = GithubIssuesRepository()
+    //    static let shared = GithubIssuesRepository()
     //UseCaseでのエラーを防ぐためにpublic指定
     public init () {}
 

--- a/GithubAPIPractice/Models/Infra/GithubIssuesRepository.swift
+++ b/GithubAPIPractice/Models/Infra/GithubIssuesRepository.swift
@@ -9,10 +9,6 @@ import Foundation
 import RxSwift
 
 final class GithubIssuesRepository: GithubIssuesRepositoryProtocol {
-    
-    //シングルトンにする
-    //テスタブルじゃなくなってしまうから、避けた方がいい
-    //    static let shared = GithubIssuesRepository()
     //UseCaseでのエラーを防ぐためにpublic指定
     public init () {}
 

--- a/GithubAPIPractice/ViewModels/DetailViewModel.swift
+++ b/GithubAPIPractice/ViewModels/DetailViewModel.swift
@@ -11,6 +11,7 @@ import RxCocoa
 
 protocol DetailViewModelOutput {
     
+    //全部Driverに変更する
     var title: Observable<String> { get }
     var body: Observable<String> { get }
     var url: Observable<URL> { get }

--- a/GithubAPIPractice/ViewModels/DetailViewModel.swift
+++ b/GithubAPIPractice/ViewModels/DetailViewModel.swift
@@ -12,10 +12,10 @@ import RxCocoa
 protocol DetailViewModelOutput {
     
     //全部Driverに変更する
-    var title: Observable<String> { get }
-    var body: Observable<String> { get }
-    var url: Observable<URL> { get }
-    var updatedAt: Observable<String> { get }
+    var title: Driver<String> { get }
+    var body: Driver<String> { get }
+    var url: Driver<URL> { get }
+    var updatedAt: Driver<String> { get }
 }
 
 final class DetailViewModel: DetailViewModelOutput {
@@ -24,16 +24,16 @@ final class DetailViewModel: DetailViewModelOutput {
     
     /*Outputに関する記述*/
     //outputsはinputsでViewControllerから受け取ったイベントによって処理をして、その結果をViewControllerに返すのでObservableを使う。
-    let title: Observable<String>
-    let body: Observable<String>
-    let url: Observable<URL>
-    let updatedAt: Observable<String>
+    let title: Driver<String>
+    let body: Driver<String>
+    let url: Driver<URL>
+    let updatedAt: Driver<String>
     
     init(issue: Issue) {
         //justは、単一のものを流すことができる
-        self.title = Observable.just(issue.title)
-        self.body = Observable.just(issue.body)
-        self.url = Observable.just(issue.url)
-        self.updatedAt = Observable.just(issue.updatedAt)
+        self.title = Driver.just(issue.title)
+        self.body = Driver.just(issue.body)
+        self.url = Driver.just(issue.url)
+        self.updatedAt = Driver.just(issue.updatedAt)
     }
 }

--- a/GithubAPIPractice/ViewModels/IssueListViewModel.swift
+++ b/GithubAPIPractice/ViewModels/IssueListViewModel.swift
@@ -18,7 +18,7 @@ final class IssueListViewModel: IssueListViewModelOutput {
     
     private let disposeBag = DisposeBag()
     private var issue: [Issue]!
-    private let useCase = IssueListUseCase()
+    private let useCase = IssueListUseCase(repository: GithubIssuesRepository())
     
     //    privateをつけないと、ViewController側からViewModel内のshowLoadingに対して直接acceptしてデータを流すことが出来てしまいます。
     private let showLoadingRelay = BehaviorRelay<Bool>(value: true)

--- a/GithubAPIPractice/Views/DetailViewController.swift
+++ b/GithubAPIPractice/Views/DetailViewController.swift
@@ -31,11 +31,11 @@ final class DetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        bind()
+        setupBindings()
     }
 
     //labelにIssueListViewControllerから受け取ったIssueを元に、表示を行う
-    private func bind() {
+    private func setupBindings() {
         self.viewModel.title
             .bind(to: self.titleLabel.rx.text)
             .disposed(by: disposeBag)

--- a/GithubAPIPractice/Views/DetailViewController.swift
+++ b/GithubAPIPractice/Views/DetailViewController.swift
@@ -37,20 +37,20 @@ final class DetailViewController: UIViewController {
     //labelにIssueListViewControllerから受け取ったIssueを元に、表示を行う
     private func setupBindings() {
         self.viewModel.title
-            .bind(to: self.titleLabel.rx.text)
+            .drive(titleLabel.rx.text)
             .disposed(by: disposeBag)
         
         self.viewModel.body
-            .bind(to: self.bodyLabel.rx.text)
+            .drive(bodyLabel.rx.text)
             .disposed(by: disposeBag)
         
         self.viewModel.updatedAt
-            .bind(to: self.updatedAtLabel.rx.text)
+            .drive(updatedAtLabel.rx.text)
             .disposed(by: disposeBag)
         //textViewにリンク埋め込みでWebView開くように実装したかったが、やり方わからなかったのでボタンに表示している
         self.viewModel.url
             .map{$0 .absoluteString}
-            .bind(to: urlButton.rx.title())
+            .drive(urlButton.rx.title())
             .disposed(by: disposeBag)
     }
     

--- a/GithubAPIPractice/Views/IssueListViewController.swift
+++ b/GithubAPIPractice/Views/IssueListViewController.swift
@@ -45,6 +45,19 @@ final class IssueListViewController: UIViewController {
         }).disposed(by: disposeBag)
     }
     
+//    weak self キャプチャ漏れを確認するための参考
+//    private func cellTapped() {
+//        // tableViewのセルをタップした時のメソッド
+//        tableView.rx.itemSelected
+//            .subscribe(onNext: { [weak self] indexPath in
+//                guard let strongSelf = self else { return }
+//                //詳細画面に飛ばす
+//                //値渡しもする
+//                Router.shared.showDetailView(from: strongSelf)
+//            })
+//            .disposed(by: disposeBag)
+//    }
+    
     //request -> 表示の間だけくるくる回るようにしたいが、実装できなかったです
     //出てきたけどよくわからなかったもの "https://github.com/ReactiveX/RxSwift/blob/main/RxExample/RxExample/Services/ActivityIndicator.swift"
     
@@ -68,7 +81,6 @@ extension IssueListViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        //issueに値が入っていない？
         let issue = viewModel.cellContent(at: indexPath)
         let cell = tableView.dequeueReusableCustomCell(with: IssueListTableViewCell.self)
         cell.setUp(issue: issue)
@@ -77,5 +89,8 @@ extension IssueListViewController: UITableViewDataSource {
 }
 
 extension IssueListViewController: UITableViewDelegate {
-
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let issue = viewModel.cellContent(at: indexPath)
+        Router.shared.showDetailView(from: self, issue: issue)
+    }
 }


### PR DESCRIPTION
https://app.asana.com/0/1202068927070771/1202104788174231

https://app.asana.com/0/1202068927070771/1202090985460790

RxDataSourcesを使わない実装にしました。
また、シングルトンを使っていた部分をprotocolを作って適合させることで、修正しました。
